### PR TITLE
schema_redundant_indexes: only drop the longer index if both indexes are unique

### DIFF
--- a/views/i_s/schema_redundant_indexes.sql
+++ b/views/i_s/schema_redundant_indexes.sql
@@ -58,7 +58,7 @@ VIEW schema_redundant_indexes (
     dominant_keys.non_unique AS dominant_index_non_unique,
     IF(redundant_keys.subpart_exists OR dominant_keys.subpart_exists, 1 ,0) AS subpart_exists,
     CONCAT(
-      'ALTER TABLE `', redundant_keys.table_schema, '`.`', redundant_keys.table_name, '` DROP ', IF(redundant_keys.non_unique = 0, '/* UNIQUE */',''), 'INDEX `', redundant_keys.index_name, '`'
+      'ALTER TABLE `', redundant_keys.table_schema, '`.`', redundant_keys.table_name, '` DROP ', IF(redundant_keys.non_unique = 0, '/* UNIQUE */ ',''), 'INDEX `', redundant_keys.index_name, '`'
       ) AS sql_drop_index
   FROM
     x$schema_flattened_keys AS redundant_keys

--- a/views/i_s/schema_redundant_indexes.sql
+++ b/views/i_s/schema_redundant_indexes.sql
@@ -88,5 +88,6 @@ VIEW schema_redundant_indexes (
         /* Unique prefix columns */
         LOCATE(CONCAT(dominant_keys.index_columns, ','), redundant_keys.index_columns) = 1
         AND dominant_keys.non_unique = 0
+        AND redundant_keys.non_unique = 0
       )
     );

--- a/views/i_s/schema_redundant_indexes.sql
+++ b/views/i_s/schema_redundant_indexes.sql
@@ -58,7 +58,7 @@ VIEW schema_redundant_indexes (
     dominant_keys.non_unique AS dominant_index_non_unique,
     IF(redundant_keys.subpart_exists OR dominant_keys.subpart_exists, 1 ,0) AS subpart_exists,
     CONCAT(
-      'ALTER TABLE `', redundant_keys.table_schema, '`.`', redundant_keys.table_name, '` DROP INDEX `', redundant_keys.index_name, '`'
+      'ALTER TABLE `', redundant_keys.table_schema, '`.`', redundant_keys.table_name, '` DROP ', IF(redundant_keys.non_unique = 0, '/* UNIQUE */',''), 'INDEX `', redundant_keys.index_name, '`'
       ) AS sql_drop_index
   FROM
     x$schema_flattened_keys AS redundant_keys


### PR DESCRIPTION
In the verified bug report https://bugs.mysql.com/bug.php?id=86660 I posited that you shouldn't mark a non-unique index as redundant if its prefix is the same as an existing unique index. This is because the longer non-unique index could be used as a covering index and dropping it could be a performance degradation. 

My opinion now is that we shouldn't suggest dropping that second, longer index unless it is also unique.

If you have a unique index `(a, b)` and another unique index `(a, b, c)`, then `(a, b, c)` is redundant because it's less selective than (a, b) in terms of uniqueness checks. You have a redundant uniqueness constraint which requires a bit more work in checking for every write to the table. It might still be a covering index but it is bad practice in its current form.

This PR makes two changes:
- in the `/* Unique prefix columns */` section, check for uniqueness on both indexes, not just the dominant key's
- add a `/* UNIQUE */` comment in the `DROP TABLE` statement if the redundant index is unique; it'll be ignored by MySQL if copied and pasted verbatim but would signal to a human reading it that the index is unique

Example:

```sql
CREATE TABLE `redundant_indexes` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `foo_id` int(11) NOT NULL,
  `bar_id` int(11) NOT NULL,
  `baz` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_foo_id_bar_id` (`foo_id`,`bar_id`),
  KEY `index_foo_id_bar_id_baz` (`foo_id`,`bar_id`,`baz`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

CREATE TABLE `redundant_unique_indexes` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `foo_id` int(11) NOT NULL,
  `bar_id` int(11) NOT NULL,
  `baz` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_foo_id_bar_id` (`foo_id`,`bar_id`),
  UNIQUE KEY `index_foo_id_bar_id_baz` (`foo_id`,`bar_id`,`baz`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8

# Expected output
*************************** 1. row ***************************
              table_schema: ggunson
                table_name: redundant_unique_indexes
      redundant_index_name: index_foo_id_bar_id_baz
   redundant_index_columns: foo_id,bar_id,baz
redundant_index_non_unique: 0
       dominant_index_name: index_foo_id_bar_id
    dominant_index_columns: foo_id,bar_id
 dominant_index_non_unique: 0
            subpart_exists: 0
            sql_drop_index: ALTER TABLE `ggunson`.`redundant_unique_indexes` DROP /* UNIQUE */ INDEX `index_foo_id_bar_id_baz`
1 row in set (0.01 sec)
```
